### PR TITLE
Fix express.static to use proper build folder location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1037,7 +1037,7 @@ app.use( session({
   saveUninitialized: true
 }));
 app.use( checkForSession );
-app.use( express.static( `${__dirname}/build` ) );
+app.use( express.static( `${__dirname}/../build` ) );
 
 // Swag
 app.get( '/api/swag', swag_controller.read );


### PR DESCRIPTION
This is based on a student and mentor suggestion. It seems like this solution has the wrong directory for the build folder, and without this fix, students will see "Cannot GET /".