### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,7 +565,7 @@ In this step, we will create endpoints that will call the methods on our control
 * Create the following endpoints: ( `request method`, `url`, `controller method` )
   * `GET` - `/api/products` - `getAll`.
   * `GET` - `/api/products/:id` - `getOne`.
-  * `PUT` - `/api/products/:id?desc=...` - `update`.
+  * `PUT` - `/api/products/:id` - `update`.
   * `POST` - `/api/products` - `create`.
   * `DELETE` - `/api/products/:id` - `delete`.
 


### PR DESCRIPTION
Removed `?desc=...` from instructions for endpoints as it is misleading and caused many students to have endpoints that literally included it which is incorrect as query parameters are passed on the request url.